### PR TITLE
OPENMOTICS_OUTPUT_TYPE_TO_NAME: add HEATER, SHUTTER_RELAY.

### DIFF
--- a/src/pyhaopenmotics/openmoticsgw/models/const.py
+++ b/src/pyhaopenmotics/openmoticsgw/models/const.py
@@ -19,6 +19,8 @@ OPENMOTICS_OUTPUT_TYPE_TO_NAME = {
     6: "GENERIC",
     7: "MOTOR",
     8: "VENTILATION",
+    9: "HEATER",
+    127: "SHUTTER_RELAY",
     255: "LIGHT",
 }
 


### PR DESCRIPTION
Syncs with https://github.com/openmotics/gateway/blob/develop/src/enums.py.

Fixes https://github.com/openmotics/home-assistant/issues/14#issuecomment-1278877743.

@woutercoppens ptal.