### PR TITLE
Fix sensor model no data (#1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyhaopenmotics"
-version = "0.0.2"
+version = "0.0.3"
 description = "Asynchronous Python client for the OpenMotics API."
 authors = ["Wouter Coppens <wouter.coppens@gmail.com>"]
 maintainers = ["Wouter Coppens <wouter.coppens@gmail.com>"]

--- a/src/pyhaopenmotics/__version__.py
+++ b/src/pyhaopenmotics/__version__.py
@@ -1,3 +1,3 @@
 """Asynchronous Python client the OpenMotics API."""
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/src/pyhaopenmotics/cloud/models/sensor.py
+++ b/src/pyhaopenmotics/cloud/models/sensor.py
@@ -43,7 +43,7 @@ class Sensor(BaseModel):
     name: str
     location: Location | None
     physical_quantity: str | None
-    status: Status
+    status: Optional[Status]
     last_state_change: float | None
     version: Optional[str] = Field(..., alias="_version")
 


### PR DESCRIPTION
A sensor that is not receiving data (a virtual one) has the status as `null`. If the status field is not set as optional the integration fails as it cannot accept `null | none` as a value.

Signed-off-by: Tiago Pires <tandrepires@gmail.com>

# Proposed Changes

I've a few virtual sensors that might have a value or not - depends if they connect and update the value - and if they can't and openmotics tries to update it fails completely. the `status` field has the value `null` instead of the expected object.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
